### PR TITLE
Fix missing breakpoint in configuration

### DIFF
--- a/resources/assets/sass/_variable.scss
+++ b/resources/assets/sass/_variable.scss
@@ -22,7 +22,7 @@ $breakpoint-horizontal: (
     tiny: 400px,
     small: 600px,
     medium: 800px,
-    regular: 1000px,
+    normal: 1000px,
     large: 1200px
 );
 


### PR DESCRIPTION
Encountered this during set up and thought it might be a useful fix. The breakpoint "normal" is referenced in the grid file, and compilation will throw an error unless we enter it into our breakpoint config. I have made the assumption that "normal" => "regular"

:v: 